### PR TITLE
Update get_urls function to return urlpatterns

### DIFF
--- a/customuser/accounts/admin.py
+++ b/customuser/accounts/admin.py
@@ -68,12 +68,15 @@ class CustomUserAdmin(admin.ModelAdmin):
         return super(CustomUserAdmin, self).get_form(request, obj, **defaults)
 
     def get_urls(self):
-        from django.conf.urls import patterns
-        return patterns('',
-                        (r'^(\d+)/password/$',
-                         self.admin_site.admin_view(self.user_change_password))
-                        ) + super(CustomUserAdmin, self).get_urls()
-
+        from django.conf.urls import url,include
+        
+        urlpatterns = [
+                url(r'^(\d+)/password/$', self.admin_site.admin_view(self.user_change_password)),  
+                
+        ]
+        urlpatterns += super(CustomUserAdmin, self).get_urls()
+        return urlpatterns
+    
     def lookup_allowed(self, lookup, value):
         # See #20078: we don't want to allow any lookups involving passwords.
         if lookup.startswith('password'):

--- a/customuser/accounts/admin.py
+++ b/customuser/accounts/admin.py
@@ -68,7 +68,7 @@ class CustomUserAdmin(admin.ModelAdmin):
         return super(CustomUserAdmin, self).get_form(request, obj, **defaults)
 
     def get_urls(self):
-        from django.conf.urls import url,include
+        from django.conf.urls import url
         
         urlpatterns = [
                 url(r'^(\d+)/password/$', self.admin_site.admin_view(self.user_change_password)),  


### PR DESCRIPTION
Use of patterns is deprecated since django 1.8.  You can use plain lists now.
This would now work for django >1.9 also fix the "ImportError: cannot import name 'patterns'" error.